### PR TITLE
 new update command for reservations thread

### DIFF
--- a/mfaliquot/application/__init__.py
+++ b/mfaliquot/application/__init__.py
@@ -671,6 +671,31 @@ class SequencesManager(_SequencesData):
           return success, DNEs, not_reserveds, wrong_reserveds
 
 
+     def update_seqs(self, name, seqs):
+          '''Update the `seqs` and warn if reserved to a different user. Raises ValueError if seq does
+          not exist. Returns (successes, DNEs, wrong_reserveds) '''
+          if not self._have_lock: raise LockError("Can't use SequencesManager.update_seqs() without lock!")
+          success, DNEs, wrong_reserveds = [], [], []
+          for seq in seqs:
+               if seq not in self:
+                    DNEs.append(seq)
+                    continue
+
+               current = self[seq].res
+
+               if not current or name == current:
+                    success.append(seq)
+               else:
+                    success.append(seq) # for now allow updating someone elses seqs
+                    wrong_reserveds.append((seq, current))
+
+          if DNEs: _logger.warning("update_seqs ({}): seqs don't exist: {}".format(name, DNEs))
+          if wrong_reserveds: _logger.warning("update_seqs ({}): seqs aren't reserved by updatee: {}".format(name, wrong_reserveds))
+          if success: _logger.info("update_seqs ({}): successfully queued for update {}".format(name, success))
+
+          return success, DNEs, wrong_reserveds
+
+
      def calc_common_stats(self):
           sizes = Counter(); lens = Counter(); guides = Counter(); progs = Counter(); cofacts = Counter()
           totsiz = 0; totlen = 0; avginc = 0; totprog = 0; data_total = 0

--- a/mfaliquot/application/fdb.py
+++ b/mfaliquot/application/fdb.py
@@ -99,6 +99,27 @@ class FDBStatus(Enum):
      CompositePartiallyFactored = auto()
      CompositeFullyFactored = auto()
 
+def _canonicalize_known_factors(smalls, bigs, comps):
+     factors = " * ".join(small for small in smalls)
+     size = 0
+     for small in smalls:
+          if '^' in small:
+               base, exp = small.split('^')
+               size += log10(int(base))*int(exp)
+          else:
+               size += log10(int(small))
+
+     if bigs:
+          for big in bigs:
+               factors += " * P"+big
+               size += int(big)
+
+     for comp in comps:
+          factors += ' * C'+comp
+          cofactor = int(comp)
+          size += cofactor
+
+     return factors, cofactor, size
 
 def query_id_status(fdb_id, tries=5):
      '''Returns None on network error, raises FDBDataError on bad data, or an FDBStatus otherwise.'''
@@ -115,7 +136,17 @@ def query_id_status(fdb_id, tries=5):
                        ('P', FDBStatus.Prime), ('U', FDBStatus.Unknown)):
 
                if f"<td>{s}</td>" in page:
-                    return e
+                    s = ""
+                    if ( e is FDBStatus.CompositePartiallyFactored):
+                         comps = COMPOSITEREGEX.findall(page)
+                         smalls = SMALLFACTREGEX.findall(page)
+                         bigs = LARGEFACTREGEX.findall(page)
+                         if not smalls:
+                              raise FDBDataError(f'Seq {seq}: no smalls match')
+                         if smalls[0][0] != '2':
+                              raise FDBDataError(f'Seq {seq}: no 2 in the smalls!')
+                         factors = _canonicalize_known_factors(smalls, bigs, comps)[0] # only need first element of tuple
+                    return e, factors
 
      return FDBDataError(f'fdb id {fdb_id} failed to produce a valid status after {tries} tries')
 
@@ -186,27 +217,7 @@ def _process_ali_data(seq, page):
      if smalls[0][0] != '2':
           raise FDBDataError(f'Seq {seq}: no 2 in the smalls!')
 
-     factors = " * ".join(small for small in smalls)
-     size = 0
-     for small in smalls:
-          if '^' in small:
-               base, exp = small.split('^')
-               size += log10(int(base))*int(exp)
-          else:
-               size += log10(int(small))
-
-     if bigs:
-          for big in bigs:
-               factors += " * P"+big
-               size += int(big)
-
-     if not comps:
-          raise FDBDataError(f'Seq {seq}: no comps match')
-
-     for comp in comps:
-          factors += ' * C'+comp
-          cofactor = int(comp)
-          size += cofactor
+     factors, cofactor, size = _canonicalize_known_factors(smalls, bigs, comps)
 
      # the digit size overestimates the actual log of a given prime by a small fraction,
      # hence allow slight excess of size over ali.size

--- a/mfaliquot/application/forum_xaction.py
+++ b/mfaliquot/application/forum_xaction.py
@@ -66,10 +66,10 @@ def spider_res_thread(last_pid):
      if all_posts:
           _order_posts(all_posts) # Assert order, ignore lowest pid retval
           for pid, name, msg in all_posts:
-               adds, drops = _read_msg(msg)
-               if adds or drops:
-                    _logger.info(f'post id {pid}: {name} adding {adds}, dropping {drops}')
-               all_res.append((name, adds, drops))
+               adds, drops, updates = _read_msg(msg)
+               if adds or drops or updates:
+                    _logger.info(f'post id {pid}: {name} adding {adds}, dropping {drops}, updating {updates}')
+               all_res.append((name, adds, drops, updates))
           last_pid = all_posts[-1][0] # Highest PID processed
      else:
           _logger.info("no new res thread posts!")
@@ -83,6 +83,7 @@ def _read_msg(msg):
      such list of sequences.'''
      add = []; addkws = ('Reserv', 'reserv', 'Add', 'add', 'Tak', 'tak')
      drop = []; dropkws = ('Unreserv', 'unreserv', 'Drop', 'drop', 'Releas', 'releas')
+     update = []; updatekws = ('Update', 'update')
 
      for line in msg.splitlines():
           if any(kw in line for kw in dropkws):
@@ -91,8 +92,11 @@ def _read_msg(msg):
           elif any(kw in line for kw in addkws):
                for s in SEQ_REGEX.findall(line):
                     add.append(int(s))
+          elif any(kw in line for kw in updatekws):
+               for s in SEQ_REGEX.findall(line):
+                    update.append(int(s))
 
-     return tuple(add), tuple(drop)
+     return tuple(add), tuple(drop), tuple(update)
 
 
 # Begin the parsers, converts the various HTML into Python data structures for processing

--- a/mfaliquot/application/reservations.py
+++ b/mfaliquot/application/reservations.py
@@ -113,10 +113,11 @@ def update_apply_all_res(seqinfo, last_pid, mass_reses):
           mass_reses_out.append([reservee, dups, unknowns, dropres])
 
      out = []
-     for name, adds, drops in thread_res:
+     for name, adds, drops, updates in thread_res:
           addres = seqinfo.reserve_seqs(name, adds)
           dropres = seqinfo.unreserve_seqs(name, drops)
-          out.append((name, addres, dropres))
+          updateres = seqinfo.update_seqs(name, updates)
+          out.append((name, addres, dropres, updateres))
 
      for name_adds, lst in zip(mass_adds, mass_reses_out):
           lst.append(seqinfo.reserve_seqs(*name_adds))

--- a/scripts/reservations.py
+++ b/scripts/reservations.py
@@ -55,11 +55,12 @@ def do_spider(seqinfo):
      LOGGER.info("Saving reservation changes to file")
      seqinfo.write() # "Atomic"
      # prepare a list of all res-changed seqs: manual drops, then manual adds, then
-     # mass drops then mass adds. Overflows get priority 0 (slight race condition
-     # with update_priorities.py)
+     # manual updates, then mass drops, then mass adds. Overflows get priority 0
+     # (slight race condition with update_priorities.py)
      # TODO: maybe factor this out into the class?
-     seqs = [seq for name, addres, dropres in thread_out for seq in dropres[0]]
-     seqs.extend(seq for name, addres, dropres in thread_out for seq in addres[0])
+     seqs = [seq for name, addres, dropres, updateres in thread_out for seq in dropres[0]]
+     seqs.extend(seq for name, addres, dropres, updateres in thread_out for seq in addres[0])
+     seqs.extend(seq for name, addres, dropres, updateres in thread_out for seq in updateres[0])
      # mass_reses_out = list-of [name, dups, unknowns, dropres, addres]
      seqs.extend(seq for name, _, _, dropres, addres in mass_out for seq in dropres[0])
      seqs.extend(seq for name, _, _, dropres, addres in mass_out for seq in addres[0])


### PR DESCRIPTION
- Adds 'Update' as a suitable command for the MF reservations thread. This will trigger a normal update as if the sequence was unreserved. For now everyone can queue an update for all sequences.

- Allow partial progress of sequences. Needed when a smaller composite on the same index is found. Introduced the 0.5 progress to correctly record that there was some action on this sequence. Adjusted parts to cope with that.

This is tested locally on my dev machine and I'm waiting for approval to deploy it on RKN.

@dubslow What about changing `priority` to `-1` in [scripts/reservations.py#L72](https://github.com/MersenneForum/MersenneForumAliquot/blob/master/scripts/reservations.py#L72) and let `update_priorities.py` ignore seqs with this value while `allseq.py` will do them first. This way we will get rid of the race condition.