### PR TITLE
 allow partial progress of sequences

### DIFF
--- a/mfaliquot/application/__init__.py
+++ b/mfaliquot/application/__init__.py
@@ -53,6 +53,7 @@ from contextlib import contextmanager
 
 
 DATETIMEFMT = '%Y-%m-%d %H:%M:%S'
+DATEFMT     = '%Y-%m-%d' # needs to be the same format as returned by fdb.id_created()
 _logger = logging.getLogger(__name__)
 
 
@@ -184,14 +185,10 @@ class AliquotSequence(list):
 
 
      def process_no_progress(self):
-          old_time = self.time
           self.time = strftime(DATETIMEFMT, gmtime())
 
           if isinstance(self.progress, int):
                self.progress = fdb.id_created(self.id)
-          # in case of partial update can't use id_created but will use last update time
-          if isinstance(self.progress, float):
-               self.progress = old_time.split(" ")[0]
 
           self.calculate_priority()
 
@@ -209,7 +206,7 @@ class AliquotSequence(list):
 
           if self.progress == 0 and self.factors != old.factors:
                _logger.info(f"fresh sequence query of {self.seq} revealed smaller cofactor but no progress")
-               self.progress = 0.5
+               self.progress = strftime(DATEFMT, gmtime())
           elif self.progress <= 0:
                _logger.info(f"fresh sequence query of {self.seq} revealed no progress")
                self.progress = fdb.id_created(self.id)

--- a/mfaliquot/application/fdb.py
+++ b/mfaliquot/application/fdb.py
@@ -136,17 +136,16 @@ def query_id_status(fdb_id, tries=5):
                        ('P', FDBStatus.Prime), ('U', FDBStatus.Unknown)):
 
                if f"<td>{s}</td>" in page:
-                    s = ""
                     if ( e is FDBStatus.CompositePartiallyFactored):
                          comps = COMPOSITEREGEX.findall(page)
                          smalls = SMALLFACTREGEX.findall(page)
                          bigs = LARGEFACTREGEX.findall(page)
                          if not smalls:
-                              raise FDBDataError(f'Seq {seq}: no smalls match')
+                              raise FDBDataError(f'fdb id {fdb_id}: no smalls match')
                          if smalls[0][0] != '2':
-                              raise FDBDataError(f'Seq {seq}: no 2 in the smalls!')
-                         factors = _canonicalize_known_factors(smalls, bigs, comps)[0] # only need first element of tuple
-                    return e, factors
+                              raise FDBDataError(f'fdb id {fdb_id}: no 2 in the smalls!')
+                         factors, cofactor = _canonicalize_known_factors(smalls, bigs, comps)[:2] # only need first two elements of tuple
+                    return e, factors, cofactor
 
      return FDBDataError(f'fdb id {fdb_id} failed to produce a valid status after {tries} tries')
 

--- a/mfaliquot/application/fdb.py
+++ b/mfaliquot/application/fdb.py
@@ -99,6 +99,27 @@ class FDBStatus(Enum):
      CompositePartiallyFactored = auto()
      CompositeFullyFactored = auto()
 
+def _canonicalize_known_factors(smalls, bigs, comps):
+     factors = " * ".join(small for small in smalls)
+     size = 0
+     for small in smalls:
+          if '^' in small:
+               base, exp = small.split('^')
+               size += log10(int(base))*int(exp)
+          else:
+               size += log10(int(small))
+
+     if bigs:
+          for big in bigs:
+               factors += " * P"+big
+               size += int(big)
+
+     for comp in comps:
+          factors += ' * C'+comp
+          cofactor = int(comp)
+          size += cofactor
+
+     return factors, cofactor, size
 
 def query_id_status(fdb_id, tries=5):
      '''Returns None on network error, raises FDBDataError on bad data, or an FDBStatus otherwise.'''
@@ -115,7 +136,17 @@ def query_id_status(fdb_id, tries=5):
                        ('P', FDBStatus.Prime), ('U', FDBStatus.Unknown)):
 
                if f"<td>{s}</td>" in page:
-                    return e
+                    s = ""
+                    if ( e is FDBStatus.CompositePartiallyFactored):
+                         comps = COMPOSITEREGEX.findall(page)
+                         smalls = SMALLFACTREGEX.findall(page)
+                         bigs = LARGEFACTREGEX.findall(page)
+                         if not smalls:
+                              raise FDBDataError(f'Seq {seq}: no smalls match')
+                         if smalls[0][0] != '2':
+                              raise FDBDataError(f'Seq {seq}: no 2 in the smalls!')
+                         factors = _canonicalize_known_factors(smalls, bigs, comps)[0] # only need first element of tuple
+                    return e, factors
 
      return FDBDataError(f'fdb id {fdb_id} failed to produce a valid status after {tries} tries')
 
@@ -186,27 +217,7 @@ def _process_ali_data(seq, page):
      if smalls[0][0] != '2':
           raise FDBDataError(f'Seq {seq}: no 2 in the smalls!')
 
-     factors = " * ".join(small for small in smalls)
-     size = 0
-     for small in smalls:
-          if '^' in small:
-               base, exp = small.split('^')
-               size += log10(int(base))*int(exp)
-          else:
-               size += log10(int(small))
-
-     if bigs:
-          for big in bigs:
-               factors += " * P"+big
-               size += int(big)
-
-     if not comps:
-          raise FDBDataError(f'Seq {seq}: no comps match')
-
-     for comp in comps:
-          factors += ' * C'+comp
-          cofactor = int(comp)
-          size += cofactor
+     factors, cofactor, size = _canonicalize_known_factors(smalls, bigs, comps)
 
      # the digit size overestimates the actual log of a given prime by a small fraction,
      # hence allow slight excess of size over ali.size


### PR DESCRIPTION
Needed when a smaller composite on the same index is found. Records the current date as last progress date and updates sequence without another FDB query.

Split of and refined from comments in #10 
Fixes #11 